### PR TITLE
Support customized page actions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+  // Use IntelliSense to learn about possible Node.js debug attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Unit Jest Tests",
+      "cwd": "${workspaceFolder}",
+      "args": [
+        "--inspect-brk",
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand",
+        "--watch",
+        "--config",
+        "${workspaceRoot}/packages/flamegrill/jest.config.js",
+        "${fileBasenameNoExtension}"
+      ],
+      "windows": {
+        "args": [
+          "--inspect-brk",
+          "${workspaceRoot}/node_modules/jest/bin/jest.js",
+          "--runInBand",
+          "--watch",
+          "--config",
+          "${workspaceRoot}/packages/flamegrill/jest.config.js",
+          "${fileBasenameNoExtension}"
+        ]
+      },
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/change/flamegrill-2020-04-23-17-01-03-xgao-page.json
+++ b/change/flamegrill-2020-04-23-17-01-03-xgao-page.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "support executing page operations before taking measures/profiling",
+  "packageName": "flamegrill",
+  "email": "xgao@microsoft.com",
+  "commit": "355b574566a201ce7c8e31be9c55472651c85310",
+  "date": "2020-04-24T00:01:03.420Z"
+}

--- a/change/flamegrill-2020-04-23-17-01-03-xgao-page.json
+++ b/change/flamegrill-2020-04-23-17-01-03-xgao-page.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "support executing page operations before taking measures/profiling",
+  "comment": "Support customized page actions and reset default timeout to 30s instead of no timeout",
   "packageName": "flamegrill",
   "email": "xgao@microsoft.com",
   "commit": "355b574566a201ce7c8e31be9c55472651c85310",

--- a/packages/flamegrill/src/analyze/analyze.ts
+++ b/packages/flamegrill/src/analyze/analyze.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { ScenarioConfig } from '../flamegrill';
-import { ScenarioProfiles } from '../profile';
+import { ScenarioProfileConfig } from '../profile';
 import { ProcessedScenario, ProcessedScenarios } from '../process';
 
 import { analyzeFunctions, FunctionalAnalysis } from './functional';
@@ -24,7 +24,7 @@ export interface ScenarioAnalyses {
   [scenarioName: string]: ScenarioAnalysis | undefined;
 };
 
-export function analyze(processedScenarios: ProcessedScenarios, config: Required<ScenarioConfig>): ScenarioAnalyses {
+export function analyze(processedScenarios: ProcessedScenarios, config: ScenarioProfileConfig): ScenarioAnalyses {
   const scenarioAnalyses: ScenarioAnalyses = {};
 
   for (const scenarioName of Object.keys(processedScenarios)) {
@@ -41,7 +41,7 @@ export function analyze(processedScenarios: ProcessedScenarios, config: Required
 /**
  * Process profiler output and check for regressions.
  */
-function analyzeScenario(scenario: ProcessedScenario, scenarioName: string, config: Required<ScenarioConfig>): ScenarioAnalysis | undefined {
+function analyzeScenario(scenario: ProcessedScenario, scenarioName: string, config: ScenarioProfileConfig): ScenarioAnalysis | undefined {
   if (scenario.output) {
     let numTicks = getTicks(scenario.output.dataFile);
 

--- a/packages/flamegrill/src/flamegrill.ts
+++ b/packages/flamegrill/src/flamegrill.ts
@@ -16,13 +16,22 @@ export interface Scenarios {
   [scenarioName: string]: Scenario;
 };
 
-export type ScenarioConfig = {
+export interface PageActionOptions {
+  /** URL the page will navigate to. */
+  url: string;
+}
+
+/**
+ * Async page operations which will be execute before taking metrics.
+ * This will override default page operations done by flamegrill before page.metrics().
+ */
+export type PageActions = (page: ProfilePage, options: PageActionOptions) => Promise<void>;
+
+export interface ScenarioConfig {
   outDir?: string;
   tempDir?: string;
-
-  /** Any async operation which will be execute before taking metrics for the profiling page. */
-  executeBeforeMeasurement?(page: ProfilePage): Promise<void>;
-};
+  pageActions?: PageActions;
+}
 
 export interface CookResult {
   profile: ScenarioProfile;
@@ -58,7 +67,7 @@ export async function cook(scenarios: Scenarios, userConfig?: ScenarioConfig): P
   const config = {
     outDir: userConfig && userConfig.outDir ? resolveDir(userConfig.outDir) : process.cwd(),
     tempDir: userConfig && userConfig.tempDir ? resolveDir(userConfig.tempDir) : process.cwd(),
-    executeBeforeMeasurement: userConfig && userConfig.executeBeforeMeasurement,
+    pageActions: userConfig && userConfig.pageActions,
   };
   
   const profiles = await profile(scenarios, config);

--- a/packages/flamegrill/src/flamegrill.ts
+++ b/packages/flamegrill/src/flamegrill.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { profile, ScenarioProfile } from './profile';
+import { profile, ScenarioProfile, ProfilePage } from './profile';
 import { processProfiles, ProcessedScenario } from './process';
 import { analyze, ScenarioAnalysis } from './analyze';
 
@@ -18,7 +18,10 @@ export interface Scenarios {
 
 export type ScenarioConfig = {
   outDir?: string;
-  tempDir?: string; 
+  tempDir?: string;
+
+  /** Any async operation which will be execute before taking metrics for the profiling page. */
+  executeBeforeMeasurement?(page: ProfilePage): Promise<void>;
 };
 
 export interface CookResult {
@@ -54,8 +57,9 @@ function resolveDir(dirPath: string): string {
 export async function cook(scenarios: Scenarios, userConfig?: ScenarioConfig): Promise<CookResults> {
   const config = {
     outDir: userConfig && userConfig.outDir ? resolveDir(userConfig.outDir) : process.cwd(),
-    tempDir: userConfig && userConfig.tempDir ? resolveDir(userConfig.tempDir) : process.cwd()
-  }
+    tempDir: userConfig && userConfig.tempDir ? resolveDir(userConfig.tempDir) : process.cwd(),
+    executeBeforeMeasurement: userConfig && userConfig.executeBeforeMeasurement,
+  };
   
   const profiles = await profile(scenarios, config);
   const processed = await processProfiles(profiles, config);

--- a/packages/flamegrill/src/process/process.ts
+++ b/packages/flamegrill/src/process/process.ts
@@ -3,8 +3,7 @@ import path from 'path';
 import cp from 'child_process';
 import concat from 'concat-stream';
 
-import { ScenarioConfig } from '../flamegrill';
-import { ScenarioProfile, ScenarioProfiles } from '../profile';
+import { ScenarioProfile, ScenarioProfiles, ScenarioProfileConfig } from '../profile';
 
 import flamebearer from './flamebearer';
 import { addMetrics } from './metrics';
@@ -34,7 +33,7 @@ export interface ProcessedScenarios {
 
 const tickprocessor = require.resolve('../tickprocessor');
 
-export async function processProfiles(profiles: ScenarioProfiles, config: Required<ScenarioConfig>): Promise<ProcessedScenarios> {
+export async function processProfiles(profiles: ScenarioProfiles, config: ScenarioProfileConfig): Promise<ProcessedScenarios> {
   const processedScenarios: ProcessedScenarios = {};
 
   // Serialize a bunch of async generation of flamegraphs

--- a/packages/flamegrill/src/profile/__tests__/profile.test.ts
+++ b/packages/flamegrill/src/profile/__tests__/profile.test.ts
@@ -1,21 +1,14 @@
 import * as tmp from 'tmp';
 import { Browser, Page } from 'puppeteer';
 
-import { __unitTestHooks, ProfilePage } from '../profile';
+import { __unitTestHooks, ProfilePage, Profile } from '../profile';
+import { PageActions, PageActionOptions } from '../../flamegrill';
 
 describe('profileUrl', () => {
   const { profileUrl } = __unitTestHooks;
   const testUrl = 'testUrl';
   const testMetrics = { metric1: 1, metric2: 2 };
-  const testPage: Page = {
-    close: jest.fn(() => Promise.resolve()),
-    goto: jest.fn(() => {
-      return Promise.resolve(null);
-    }),
-    metrics: jest.fn(() => Promise.resolve(testMetrics)),
-    setDefaultTimeout: jest.fn(() => {}),
-    waitForSelector: jest.fn(() => Promise.resolve()),
-  } as unknown as Page;
+  let testPage: Page;
 
   const testBrowser: Browser = {
     newPage: jest.fn(() => {
@@ -32,15 +25,47 @@ describe('profileUrl', () => {
   beforeAll(() => {
     outdir = tmp.dirSync({ unsafeCleanup: true });
   });
-  
+
   afterAll(() => {
     outdir.removeCallback();
-  })
+  });
 
+  beforeEach(() => {
+    testPage = {
+      close: jest.fn(() => Promise.resolve()),
+      goto: jest.fn(() => {
+        return Promise.resolve(null);
+      }),
+      metrics: jest.fn(() => Promise.resolve(testMetrics)),
+      setDefaultTimeout: jest.fn(() => {}),
+      waitForSelector: jest.fn(() => Promise.resolve()),
+    } as unknown as Page;
+  });
+  
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  
   it('performs expected operations', async () => {
-    const executeBeforeMeasurement = async (page: ProfilePage) => { await page.waitForSelector(testSelector); } 
+    const result = await profileUrl(testBrowser, testUrl, 'testScenario', outdir.name);
 
-    const result = await profileUrl(testBrowser, testUrl, 'testScenario', outdir.name, executeBeforeMeasurement);
+    expect((testPage.goto as jest.Mock).mock.calls.length).toEqual(1);
+    expect((testPage.goto as jest.Mock).mock.calls[0][0]).toEqual(testUrl);
+    expect((testPage.close as jest.Mock).mock.calls.length).toEqual(1);
+
+    expect(logfile).toBeDefined();
+    expect(result.logFile).toEqual(logfile.name);
+    expect(result.metrics).toEqual(testMetrics);
+  });
+
+  it('performs expected operations when user defined page actions', async () => {
+    const pageActions: PageActions = async (page: ProfilePage, options: PageActionOptions) => {
+      await page.setDefaultTimeout(0);
+      await page.goto(options.url);
+      await page.waitForSelector(testSelector);
+    };
+    
+    const result = await profileUrl(testBrowser, testUrl, 'testScenario', outdir.name, pageActions);
 
     expect((testPage.setDefaultTimeout as jest.Mock).mock.calls.length).toEqual(1);
     expect((testPage.setDefaultTimeout as jest.Mock).mock.calls[0][0]).toEqual(0);

--- a/packages/flamegrill/src/profile/index.ts
+++ b/packages/flamegrill/src/profile/index.ts
@@ -1,1 +1,1 @@
-export { profile, ScenarioProfile, ScenarioProfiles } from './profile';
+export { profile, ScenarioProfile, ScenarioProfiles, ScenarioProfileConfig, ProfilePage } from './profile';

--- a/packages/flamegrill/src/profile/profile.ts
+++ b/packages/flamegrill/src/profile/profile.ts
@@ -87,7 +87,7 @@ export async function profile(scenarios: Scenarios, config: ScenarioProfileConfi
  * @param {string} testUrl Base URL supporting 'scenario' and 'iterations' query parameters.
  * @param {string} profileName Name of scenario that will be used with baseUrl.
  * @param {string} logDir Absolute path to output log profiles.
- * @param onPageNavigated Async opertaion that is executed after page is navigated.
+ * @param onPageLoad Async opertaion that is executed after page is loaded.
  * @returns {string} Log file path associated with test.
  */
 async function profileUrl(
@@ -95,7 +95,7 @@ async function profileUrl(
   testUrl: string,
   profileName: string,
   logDir: string,
-  onPageNavigated?: (page: ProfilePage) => Promise<void>
+  onPageLoad?: (page: ProfilePage) => Promise<void>
 ): Promise<Profile> {
   const logFilesBefore = fs.readdirSync(logDir);
 
@@ -125,9 +125,9 @@ async function profileUrl(
   // https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagegotourl-options
   await page.goto(testUrl);
 
-  if (onPageNavigated) {
+  if (onPageLoad) {
     console.log("Started executing user-defined page operations.");
-    await onPageNavigated(page);
+    await onPageLoad(page);
     console.log("Finished executing user-defined page operations.");
   }
 


### PR DESCRIPTION
- User can define `pageActions` to implement any page operations which override the default operations done by flamegrill before taking page metrics (calling `page.metrics`)

- Removed setting no default timeout